### PR TITLE
Add tax calculator with Excel export

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
           <li class="nav-item"><a class="nav-link" href="#images">Images to PDF</a></li>
           <li class="nav-item"><a class="nav-link" href="#datatable">JSON to Table</a></li>
           <li class="nav-item"><a class="nav-link" href="#tree">JSON Tree</a></li>
+          <li class="nav-item"><a class="nav-link" href="#tax">Tax Calculator</a></li>
           <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
         </ul>
         <button id="modeToggle" class="btn btn-outline-secondary">Dark Mode</button>
@@ -35,6 +36,7 @@
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/datatables.net@1.13.5/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/datatables.net-dt@1.13.5/css/jquery.dataTables.min.css"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script type="module" src="src/app.js"></script>
 </body>
 </html>

--- a/modules/taxCalculator.js
+++ b/modules/taxCalculator.js
@@ -1,0 +1,80 @@
+export function initTaxCalculator(container) {
+  container.innerHTML = `
+    <h2>Tax Calculator</h2>
+    <div class="row mb-3">
+      <div class="col">
+        <input type="number" id="amount" class="form-control" placeholder="Amount" />
+      </div>
+      <div class="col">
+        <input type="number" id="rate" class="form-control" placeholder="Tax Rate (%)" />
+      </div>
+      <div class="col">
+        <button id="calcBtn" class="btn btn-primary w-100">Calculate</button>
+      </div>
+    </div>
+    <table id="resultTable" class="table" style="display:none">
+      <thead><tr><th>Subtotal</th><th>Tax Rate</th><th>Tax Amount</th><th>Total</th></tr></thead>
+      <tbody></tbody>
+    </table>
+    <div id="exportBtns" class="mt-2" style="display:none">
+      <button id="pdfBtn" class="btn btn-secondary me-2">Export PDF</button>
+      <button id="csvBtn" class="btn btn-secondary me-2">Export CSV</button>
+      <button id="xlsxBtn" class="btn btn-secondary">Export Excel</button>
+    </div>
+  `;
+
+  const amountInput = container.querySelector('#amount');
+  const rateInput = container.querySelector('#rate');
+  const calcBtn = container.querySelector('#calcBtn');
+  const table = container.querySelector('#resultTable');
+  const tbody = table.querySelector('tbody');
+  const exportDiv = container.querySelector('#exportBtns');
+
+  calcBtn.addEventListener('click', () => {
+    const amount = parseFloat(amountInput.value) || 0;
+    const rate = parseFloat(rateInput.value) || 0;
+    const tax = amount * rate / 100;
+    const total = amount + tax;
+    tbody.innerHTML = `<tr><td>${amount.toFixed(2)}</td><td>${rate.toFixed(2)}%</td><td>${tax.toFixed(2)}</td><td>${total.toFixed(2)}</td></tr>`;
+    table.style.display = '';
+    exportDiv.style.display = '';
+  });
+
+  container.querySelector('#pdfBtn').addEventListener('click', async () => {
+    const { PDFDocument, StandardFonts } = PDFLib;
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage([400, 200]);
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const { width, height } = page.getSize();
+    page.drawText('Tax Calculation', { x: 20, y: height - 30, size: 16, font });
+    page.drawText('Subtotal: ' + tbody.children[0].children[0].textContent, { x: 20, y: height - 60, font });
+    page.drawText('Tax Rate: ' + tbody.children[0].children[1].textContent, { x: 20, y: height - 80, font });
+    page.drawText('Tax Amount: ' + tbody.children[0].children[2].textContent, { x: 20, y: height - 100, font });
+    page.drawText('Total: ' + tbody.children[0].children[3].textContent, { x: 20, y: height - 120, font });
+    const pdfBytes = await pdfDoc.save();
+    const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'tax.pdf';
+    link.click();
+  });
+
+  container.querySelector('#csvBtn').addEventListener('click', () => {
+    const row = Array.from(tbody.querySelectorAll('td')).map(td => td.textContent.replace('%',''));
+    const csv = 'Subtotal,Tax Rate,Tax Amount,Total\n' + row.join(',');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'tax.csv';
+    link.click();
+  });
+
+  container.querySelector('#xlsxBtn').addEventListener('click', () => {
+    const row = Array.from(tbody.querySelectorAll('td')).map(td => td.textContent);
+    const wsData = [['Subtotal','Tax Rate','Tax Amount','Total'], row];
+    const worksheet = XLSX.utils.aoa_to_sheet(wsData);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, worksheet, 'Tax');
+    XLSX.writeFile(wb, 'tax.xlsx');
+  });
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import { initImagesToPdf } from '../modules/imagesToPdf.js';
 import { initJsonToDataTable } from '../modules/jsonToDataTable.js';
 import { initJsonTreeView } from '../modules/jsonTreeView.js';
+import { initTaxCalculator } from '../modules/taxCalculator.js';
 import { initAbout } from '../modules/about.js';
 
 const app = document.getElementById('app');
@@ -16,6 +17,9 @@ function render(hash) {
       break;
     case '#tree':
       initJsonTreeView(app);
+      break;
+    case '#tax':
+      initTaxCalculator(app);
       break;
     default:
       initAbout(app);


### PR DESCRIPTION
## Summary
- add new Tax Calculator tool with PDF, CSV and Excel export options
- register the tax calculator route in the PWA
- link to it in the navigation bar
- load SheetJS library in `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b1c13494c832c960101b01cb18f87