### PR TITLE
Add jQuery asset to service worker cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -10,6 +10,7 @@ const ASSETS = [
   './modules/about.js',
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css',
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js',
+  'https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js',
   'https://cdn.jsdelivr.net/npm/pdf-lib@1.17.1/dist/pdf-lib.min.js',
   'https://cdn.jsdelivr.net/npm/datatables.net@1.13.5/js/jquery.dataTables.min.js',
   'https://cdn.jsdelivr.net/npm/datatables.net-dt@1.13.5/css/jquery.dataTables.min.css'


### PR DESCRIPTION
## Summary
- cache jQuery in service worker for offline usage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b1c10ef78832c88853517272f448b