### PR TITLE
Add multiple utility modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,24 @@
 This project is a collection of offline-first tools bundled as a Progressive Web App.
 It works entirely in the browser and can be hosted statically (e.g., GitHub Pages).
 
-## Features (partial implementation)
+## Features
 - Multiple Images to PDF converter
 - JSON to DataTable viewer
 - JSON Tree View
+- PDF to Word converter
+- Word to PDF converter
+- Rich WYSIWYG editor with import/export for Word and PDF
+- XML↔JSON converter
+- Postman-like REST API tester
+- WebSocket test suite
 - About page
 
 Additional tools can be added in `modules/`.
+
+## Usage
+Navigate using the menu links in `index.html`. Each module runs fully in the
+browser and requires no server. Simply open the page and select the desired
+tool. Conversions happen client side using libraries loaded from CDNs.
 
 ## Development
 Simply open `index.html` in a modern browser or serve the directory with a static server.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
           <li class="nav-item"><a class="nav-link" href="#images">Images to PDF</a></li>
           <li class="nav-item"><a class="nav-link" href="#datatable">JSON to Table</a></li>
           <li class="nav-item"><a class="nav-link" href="#tree">JSON Tree</a></li>
+          <li class="nav-item"><a class="nav-link" href="#pdftoword">PDF→Word</a></li>
+          <li class="nav-item"><a class="nav-link" href="#wordtopdf">Word→PDF</a></li>
+          <li class="nav-item"><a class="nav-link" href="#editor">WYSIWYG</a></li>
+          <li class="nav-item"><a class="nav-link" href="#xmljson">XML↔JSON</a></li>
+          <li class="nav-item"><a class="nav-link" href="#apitester">API Tester</a></li>
+          <li class="nav-item"><a class="nav-link" href="#websocket">WebSocket</a></li>
           <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
         </ul>
         <button id="modeToggle" class="btn btn-outline-secondary">Dark Mode</button>
@@ -35,6 +41,14 @@
   <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/datatables.net@1.13.5/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/datatables.net-dt@1.13.5/css/jquery.dataTables.min.css"></script>
+  <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.10.111/build/pdf.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mammoth@1.4.19/dist/mammoth.browser.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docx@8.0.3/build/index.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/html-docx-js@0.4.1/dist/html-docx.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/x2js@3.6.1/x2js.min.js"></script>
   <script type="module" src="src/app.js"></script>
 </body>
 </html>

--- a/modules/apiTester.js
+++ b/modules/apiTester.js
@@ -1,0 +1,28 @@
+export function initApiTester(container) {
+  container.innerHTML = `
+    <h2>REST API Tester</h2>
+    <div class="row g-2">
+      <div class="col-md-2"><select id="method" class="form-select"><option>GET</option><option>POST</option><option>PUT</option><option>DELETE</option></select></div>
+      <div class="col-md-10"><input id="url" class="form-control" placeholder="https://api.example.com"/></div>
+    </div>
+    <textarea id="headers" class="form-control mt-2" rows="2" placeholder="{\"Content-Type\":\"application/json\"}"></textarea>
+    <textarea id="body" class="form-control mt-2" rows="4" placeholder="Request body"></textarea>
+    <button id="send" class="btn btn-primary mt-2">Send</button>
+    <pre id="response" class="mt-3"></pre>
+  `;
+  container.querySelector('#send').addEventListener('click', async () => {
+    const method = container.querySelector('#method').value;
+    const url = container.querySelector('#url').value;
+    const headersText = container.querySelector('#headers').value;
+    let headers = {};
+    try { headers = headersText ? JSON.parse(headersText) : {}; } catch {}
+    const body = container.querySelector('#body').value || undefined;
+    try {
+      const res = await fetch(url, { method, headers, body: ['GET','HEAD'].includes(method)?undefined:body });
+      const text = await res.text();
+      container.querySelector('#response').textContent = text;
+    } catch (e) {
+      container.querySelector('#response').textContent = 'Error: ' + e;
+    }
+  });
+}

--- a/modules/pdfToWord.js
+++ b/modules/pdfToWord.js
@@ -1,0 +1,30 @@
+export function initPdfToWord(container) {
+  container.innerHTML = `
+    <h2>PDF to Word</h2>
+    <input type="file" id="pdfFile" accept="application/pdf" class="form-control" />
+    <button id="pdfToWordBtn" class="btn btn-primary mt-2">Convert to Word</button>
+  `;
+  const input = container.querySelector('#pdfFile');
+  const btn = container.querySelector('#pdfToWordBtn');
+  btn.addEventListener('click', async () => {
+    if (!input.files.length) return;
+    const file = input.files[0];
+    const arrayBuffer = await file.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    let text = '';
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const content = await page.getTextContent();
+      text += content.items.map(it => it.str).join(' ') + '\n';
+    }
+    // create a simple docx with the extracted text
+    const doc = new docx.Document({
+      sections: [{ properties: {}, children: [new docx.Paragraph(text)] }]
+    });
+    const blob = await docx.Packer.toBlob(doc);
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = file.name.replace(/\.pdf$/i, '.docx');
+    link.click();
+  });
+}

--- a/modules/websocketTester.js
+++ b/modules/websocketTester.js
@@ -1,0 +1,35 @@
+export function initWebsocketTester(container) {
+  container.innerHTML = `
+    <h2>WebSocket Tester</h2>
+    <input id="wsUrl" class="form-control" placeholder="wss://echo.websocket.org" />
+    <button id="connect" class="btn btn-primary mt-2">Connect</button>
+    <div id="wsControls" style="display:none" class="mt-2">
+      <input id="wsMessage" class="form-control" placeholder="Message" />
+      <button id="sendMsg" class="btn btn-secondary mt-2">Send</button>
+      <button id="close" class="btn btn-danger mt-2 ms-2">Close</button>
+    </div>
+    <pre id="log" class="mt-3"></pre>
+  `;
+  let socket;
+  const log = msg => {
+    container.querySelector('#log').textContent += msg + '\n';
+  };
+  container.querySelector('#connect').addEventListener('click', () => {
+    const url = container.querySelector('#wsUrl').value;
+    socket = new WebSocket(url);
+    log('Connecting to ' + url);
+    socket.addEventListener('open', () => {
+      log('Connected');
+      container.querySelector('#wsControls').style.display = '';
+    });
+    socket.addEventListener('message', e => log('<< ' + e.data));
+    socket.addEventListener('close', () => log('Closed'));
+    socket.addEventListener('error', e => log('Error: ' + e));
+  });
+  container.querySelector('#sendMsg').addEventListener('click', () => {
+    const msg = container.querySelector('#wsMessage').value;
+    socket.send(msg);
+    log('>> ' + msg);
+  });
+  container.querySelector('#close').addEventListener('click', () => socket.close());
+}

--- a/modules/wordToPdf.js
+++ b/modules/wordToPdf.js
@@ -1,0 +1,18 @@
+export function initWordToPdf(container) {
+  container.innerHTML = `
+    <h2>Word to PDF</h2>
+    <input type="file" id="docxFile" accept=".doc,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document" class="form-control" />
+    <button id="wordToPdfBtn" class="btn btn-primary mt-2">Convert to PDF</button>
+  `;
+  const input = container.querySelector('#docxFile');
+  const btn = container.querySelector('#wordToPdfBtn');
+  btn.addEventListener('click', async () => {
+    if (!input.files.length) return;
+    const file = input.files[0];
+    const arrayBuffer = await file.arrayBuffer();
+    const { value: html } = await mammoth.convertToHtml({ arrayBuffer });
+    const doc = new jspdf.jsPDF();
+    await doc.html(html, { html2canvas: { scale: 0.5 } });
+    doc.save(file.name.replace(/\.(docx|doc)$/i, '.pdf'));
+  });
+}

--- a/modules/wysiwyg.js
+++ b/modules/wysiwyg.js
@@ -1,0 +1,30 @@
+export function initWysiwyg(container) {
+  container.innerHTML = `
+    <h2>Rich Editor</h2>
+    <div id="editor" style="height:200px"></div>
+    <input type="file" id="importWord" accept=".doc,.docx" class="form-control mt-2" />
+    <button id="exportWord" class="btn btn-secondary mt-2">Export Word</button>
+    <button id="exportPdf" class="btn btn-secondary mt-2 ms-2">Export PDF</button>
+  `;
+  const quill = new Quill('#editor', { theme: 'snow' });
+  const importInput = container.querySelector('#importWord');
+  importInput.addEventListener('change', async () => {
+    if (!importInput.files.length) return;
+    const arrayBuffer = await importInput.files[0].arrayBuffer();
+    const { value: html } = await mammoth.convertToHtml({ arrayBuffer });
+    quill.root.innerHTML = html;
+  });
+  container.querySelector('#exportWord').addEventListener('click', async () => {
+    const html = quill.root.innerHTML;
+    const blob = htmlDocx.asBlob(html);
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = 'document.docx';
+    link.click();
+  });
+  container.querySelector('#exportPdf').addEventListener('click', async () => {
+    const doc = new jspdf.jsPDF();
+    await doc.html(quill.root.innerHTML, { html2canvas: { scale: 0.5 } });
+    doc.save('document.pdf');
+  });
+}

--- a/modules/xmlJson.js
+++ b/modules/xmlJson.js
@@ -1,0 +1,27 @@
+export function initXmlJson(container) {
+  container.innerHTML = `
+    <h2>XML ↔ JSON</h2>
+    <textarea id="xmlInput" class="form-control" rows="4" placeholder="<root></root>"></textarea>
+    <button id="toJson" class="btn btn-primary mt-2">XML to JSON</button>
+    <textarea id="jsonOutput" class="form-control mt-2" rows="4" placeholder="{}"></textarea>
+    <button id="toXml" class="btn btn-secondary mt-2">JSON to XML</button>
+  `;
+  const x2js = new X2JS();
+  container.querySelector('#toJson').addEventListener('click', () => {
+    try {
+      const xml = container.querySelector('#xmlInput').value;
+      const obj = x2js.xml2js(xml);
+      container.querySelector('#jsonOutput').value = JSON.stringify(obj, null, 2);
+    } catch {
+      alert('Invalid XML');
+    }
+  });
+  container.querySelector('#toXml').addEventListener('click', () => {
+    try {
+      const obj = JSON.parse(container.querySelector('#jsonOutput').value);
+      container.querySelector('#xmlInput').value = x2js.js2xml(obj);
+    } catch {
+      alert('Invalid JSON');
+    }
+  });
+}

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,12 @@ import { initImagesToPdf } from '../modules/imagesToPdf.js';
 import { initJsonToDataTable } from '../modules/jsonToDataTable.js';
 import { initJsonTreeView } from '../modules/jsonTreeView.js';
 import { initAbout } from '../modules/about.js';
+import { initPdfToWord } from '../modules/pdfToWord.js';
+import { initWordToPdf } from '../modules/wordToPdf.js';
+import { initWysiwyg } from '../modules/wysiwyg.js';
+import { initXmlJson } from '../modules/xmlJson.js';
+import { initApiTester } from '../modules/apiTester.js';
+import { initWebsocketTester } from '../modules/websocketTester.js';
 
 const app = document.getElementById('app');
 
@@ -16,6 +22,24 @@ function render(hash) {
       break;
     case '#tree':
       initJsonTreeView(app);
+      break;
+    case '#pdftoword':
+      initPdfToWord(app);
+      break;
+    case '#wordtopdf':
+      initWordToPdf(app);
+      break;
+    case '#editor':
+      initWysiwyg(app);
+      break;
+    case '#xmljson':
+      initXmlJson(app);
+      break;
+    case '#apitester':
+      initApiTester(app);
+      break;
+    case '#websocket':
+      initWebsocketTester(app);
       break;
     default:
       initAbout(app);


### PR DESCRIPTION
## Summary
- convert PDF to Word
- convert Word to PDF
- add a rich WYSIWYG editor with Word/PDF import/export
- provide XML↔JSON conversion
- implement API tester and WebSocket tester
- integrate new modules in app and navigation
- document all utilities

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b1c0b1830832cb2d64d94b4726612