### PR TITLE
Cache all modules

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'free-web-tools-v1';
+const CACHE_NAME = 'free-web-tools-v2';
 const ASSETS = [
   './',
   './index.html',
@@ -8,6 +8,12 @@ const ASSETS = [
   './modules/jsonToDataTable.js',
   './modules/jsonTreeView.js',
   './modules/about.js',
+  './modules/pdfToWord.js',
+  './modules/wordToPdf.js',
+  './modules/wysiwyg.js',
+  './modules/xmlJson.js',
+  './modules/apiTester.js',
+  './modules/websocketTester.js',
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css',
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js',
   'https://cdn.jsdelivr.net/npm/pdf-lib@1.17.1/dist/pdf-lib.min.js',


### PR DESCRIPTION
## Summary
- add remaining modules to service worker assets
- bump service worker cache version

## Testing
- `node - <<'NODE'
const fs = require('fs');
const content = fs.readFileSync('service-worker.js','utf8');
const modules = [
  './modules/pdfToWord.js',
  './modules/wordToPdf.js',
  './modules/wysiwyg.js',
  './modules/xmlJson.js',
  './modules/apiTester.js',
  './modules/websocketTester.js'
];
let missing = modules.filter(m => !content.includes(m));
if(missing.length) {
  console.error('Missing:', missing);
  process.exit(1);
} else {
  console.log('All module paths present');
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_684b201afae4832c818475abfb682b44