### PR TITLE
Fix WebSocket tester placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It works entirely in the browser and can be hosted statically (e.g., GitHub Page
 - XML↔JSON converter
 - Postman-like REST API tester
 - WebSocket test suite
+- The WebSocket tester defaults to `wss://ws.postman-echo.com/raw` for echo tests
 - About page
 
 Additional tools can be added in `modules/`.

--- a/modules/websocketTester.js
+++ b/modules/websocketTester.js
@@ -1,7 +1,7 @@
 export function initWebsocketTester(container) {
   container.innerHTML = `
     <h2>WebSocket Tester</h2>
-    <input id="wsUrl" class="form-control" placeholder="wss://echo.websocket.org" />
+    <input id="wsUrl" class="form-control" placeholder="wss://ws.postman-echo.com/raw" />
     <button id="connect" class="btn btn-primary mt-2">Connect</button>
     <div id="wsControls" style="display:none" class="mt-2">
       <input id="wsMessage" class="form-control" placeholder="Message" />


### PR DESCRIPTION
## Summary
- update default URL in websocket tester module
- document new echo server in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b201d399c832c94ebe54ca462528a