### PR TITLE
Improve service worker

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -58,5 +58,14 @@ btn.addEventListener('click', () => {
 
 // Register service worker
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('service-worker.js');
+  navigator.serviceWorker.register('service-worker.js').then(reg => {
+    navigator.serviceWorker.addEventListener('message', event => {
+      if (event.data && event.data.type === 'UPDATE_AVAILABLE') {
+        if (confirm('A new version is available. Reload now?')) {
+          reg.waiting?.postMessage({ type: 'SKIP_WAITING' });
+          window.location.reload();
+        }
+      }
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- version cache name
- clean old caches on activate
- prompt users to reload when an update is available
- add runtime caching for modules and CDN resources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b24333d64832c8c1ccece09345ad0