### PR TITLE
Add PDF compression tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project is a collection of offline-first tools bundled as a Progressive Web
 - **JSON Tree View** – explore nested JSON in a collapsible tree
 - **PDF to Word** – convert PDF documents to Word
 - **Word to PDF** – convert Word documents to PDF
+- **Compress PDF under 5MB** – reduce PDF file size below 5MB
 - **Rich WYSIWYG editor** – basic rich‑text editor with Word/PDF import and export
 - **XML ↔ JSON** – convert data between XML and JSON formats
 - **REST API tester** – send HTTP requests similar to Postman

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
           <li class="nav-item"><a class="nav-link" href="#tree">JSON Tree</a></li>
           <li class="nav-item"><a class="nav-link" href="#pdftoword">PDF→Word</a></li>
           <li class="nav-item"><a class="nav-link" href="#wordtopdf">Word→PDF</a></li>
+          <li class="nav-item"><a class="nav-link" href="#compresspdf">Compress PDF</a></li>
           <li class="nav-item"><a class="nav-link" href="#editor">WYSIWYG</a></li>
           <li class="nav-item"><a class="nav-link" href="#xmljson">XML↔JSON</a></li>
           <li class="nav-item"><a class="nav-link" href="#apitester">API Tester</a></li>

--- a/modules/compressPdf.js
+++ b/modules/compressPdf.js
@@ -1,0 +1,41 @@
+export function initCompressPdf(container) {
+  container.innerHTML = `
+    <h2>Compress PDF under 5MB</h2>
+    <input type="file" id="pdfInput" accept="application/pdf" class="form-control" />
+    <button id="compressBtn" class="btn btn-primary mt-2">Compress & Download</button>
+    <div id="status" class="mt-2 text-danger"></div>
+  `;
+  const input = container.querySelector('#pdfInput');
+  const btn = container.querySelector('#compressBtn');
+  const status = container.querySelector('#status');
+  btn.addEventListener('click', async () => {
+    if (!input.files.length) return;
+    const file = input.files[0];
+    const arrayBuffer = await file.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    const firstPage = await pdf.getPage(1);
+    const firstViewport = firstPage.getViewport({ scale: 1 });
+    const doc = new jspdf.jsPDF({ unit: 'px', format: [firstViewport.width, firstViewport.height] });
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const viewport = page.getViewport({ scale: 1 });
+      const canvas = document.createElement('canvas');
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      await page.render({ canvasContext: canvas.getContext('2d'), viewport }).promise;
+      const imgData = canvas.toDataURL('image/jpeg', 0.6);
+      if (i > 1) doc.addPage([viewport.width, viewport.height]);
+      doc.addImage(imgData, 'JPEG', 0, 0, viewport.width, viewport.height);
+    }
+    const blob = doc.output('blob');
+    if (blob.size <= 5 * 1024 * 1024) {
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = file.name.replace(/\.pdf$/i, '-compressed.pdf');
+      link.click();
+      status.textContent = '';
+    } else {
+      status.textContent = 'Could not compress below 5MB.';
+    }
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -12,6 +12,7 @@ const ASSETS = [
   './modules/about.js',
   './modules/pdfToWord.js',
   './modules/wordToPdf.js',
+  './modules/compressPdf.js',
   './modules/wysiwyg.js',
   './modules/xmlJson.js',
   './modules/apiTester.js',

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import { initWysiwyg } from '../modules/wysiwyg.js';
 import { initXmlJson } from '../modules/xmlJson.js';
 import { initApiTester } from '../modules/apiTester.js';
 import { initWebsocketTester } from '../modules/websocketTester.js';
+import { initCompressPdf } from '../modules/compressPdf.js';
 
 const app = document.getElementById('app');
 
@@ -28,6 +29,9 @@ function render(hash) {
       break;
     case '#wordtopdf':
       initWordToPdf(app);
+      break;
+    case '#compresspdf':
+      initCompressPdf(app);
       break;
     case '#editor':
       initWysiwyg(app);


### PR DESCRIPTION
## Summary
- implement a Compress PDF tool that reduces file size under 5MB
- register new tool in navigation and routing
- document the new feature in README
- cache the module in the service worker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bb6ffa808832ca285f11b283fa9a1