### PR TITLE
Add image OCR tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 ## 0.1.0
 - Initial release with PDF, Word and JSON tools.
+
+## 0.2.0
+- Added Image OCR tool using Tesseract.js.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project is a collection of offline-first tools bundled as a Progressive Web
 
 ## Features
 - **Images to PDF** – combine multiple images into a single PDF file
+- **Image OCR** – extract text from pictures using Tesseract.js
 - **JSON to DataTable** – render JSON arrays as an interactive table
 - **JSON Tree View** – explore nested JSON in a collapsible tree
 - **PDF to Word** – convert PDF documents to Word

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <li class="nav-item"><a class="nav-link" href="#images">Images to PDF</a></li>
+          <li class="nav-item"><a class="nav-link" href="#ocr">Image OCR</a></li>
           <li class="nav-item"><a class="nav-link" href="#datatable">JSON to Table</a></li>
           <li class="nav-item"><a class="nav-link" href="#tree">JSON Tree</a></li>
           <li class="nav-item"><a class="nav-link" href="#pdftoword">PDF→Word</a></li>
@@ -50,6 +51,7 @@
   <link href="https://cdn.jsdelivr.net/npm/quill@1.3.7/dist/quill.snow.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/html-docx-js@0.4.1/dist/html-docx.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/x2js@3.6.1/x2js.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
   <script type="module" src="src/app.js"></script>
 </body>
 </html>

--- a/modules/imageOcr.js
+++ b/modules/imageOcr.js
@@ -1,0 +1,22 @@
+export function initImageOcr(container) {
+  container.innerHTML = `
+    <h2>Image OCR</h2>
+    <input type="file" id="ocrImage" accept="image/*" class="form-control" />
+    <button id="ocrBtn" class="btn btn-primary mt-2">Extract Text</button>
+    <pre id="ocrResult" class="mt-3"></pre>
+  `;
+  const input = container.querySelector('#ocrImage');
+  const btn = container.querySelector('#ocrBtn');
+  const result = container.querySelector('#ocrResult');
+  btn.addEventListener('click', async () => {
+    if (!input.files.length) return;
+    const file = input.files[0];
+    result.textContent = 'Processing...';
+    try {
+      const { data: { text } } = await Tesseract.recognize(file, 'eng');
+      result.textContent = text;
+    } catch (e) {
+      result.textContent = 'Error: ' + e;
+    }
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Increment the version to bust the cache when deploying a new release
-const CACHE_VERSION = 'v3';
+const CACHE_VERSION = 'v4';
 const CACHE_NAME = `free-web-tools-${CACHE_VERSION}`;
 const ASSETS = [
   './',
@@ -13,6 +13,7 @@ const ASSETS = [
   './modules/pdfToWord.js',
   './modules/wordToPdf.js',
   './modules/compressPdf.js',
+  './modules/imageOcr.js',
   './modules/wysiwyg.js',
   './modules/xmlJson.js',
   './modules/apiTester.js',
@@ -21,7 +22,8 @@ const ASSETS = [
   'https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js',
   'https://cdn.jsdelivr.net/npm/pdf-lib@1.17.1/dist/pdf-lib.min.js',
   'https://cdn.jsdelivr.net/npm/datatables.net@1.13.5/js/jquery.dataTables.min.js',
-  'https://cdn.jsdelivr.net/npm/datatables.net-dt@1.13.5/css/jquery.dataTables.min.css'
+  'https://cdn.jsdelivr.net/npm/datatables.net-dt@1.13.5/css/jquery.dataTables.min.css',
+  'https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js'
 ];
 
 self.addEventListener('install', event => {

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import { initXmlJson } from '../modules/xmlJson.js';
 import { initApiTester } from '../modules/apiTester.js';
 import { initWebsocketTester } from '../modules/websocketTester.js';
 import { initCompressPdf } from '../modules/compressPdf.js';
+import { initImageOcr } from '../modules/imageOcr.js';
 
 const app = document.getElementById('app');
 
@@ -32,6 +33,9 @@ function render(hash) {
       break;
     case '#compresspdf':
       initCompressPdf(app);
+      break;
+    case '#ocr':
+      initImageOcr(app);
       break;
     case '#editor':
       initWysiwyg(app);

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.1.0';
+export const APP_VERSION = '0.2.0';


### PR DESCRIPTION
## Summary
- add an Image OCR tool using Tesseract.js
- hook up the new tool in `src/app.js`
- expose Image OCR in the navigation
- precache new assets and bump the service worker
- document the new feature and bump version

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_685bcdaabe40832ca4fb85945d0504ec