### PR TITLE
Improve dark mode and table security

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ Navigate using the menu links in `index.html`. Each module runs fully in the bro
 
 ## Contributing
 Pull requests are welcome. New tools should live in `modules/` and be wired up in `src/app.js` and `service-worker.js`. Keep the project lightweight and avoid server-side code.
-=======
+
+### Adding a module
+1. Create a new JavaScript file under `modules/` that exports an `initX` function.
+2. Import the file and add a new `case` in `src/app.js` so the module can be routed.
+3. Include the new file path in the `ASSETS` array of `service-worker.js` and bump `CACHE_VERSION` so the update is cached.
+
 Service worker enables offline usage after the first load.
 
 ## License

--- a/modules/jsonToDataTable.js
+++ b/modules/jsonToDataTable.js
@@ -14,7 +14,13 @@ export function initJsonToDataTable(container) {
       const table = container.querySelector('#jsonTable');
       const headers = Object.keys(data[0]);
       table.innerHTML = `<thead><tr>${headers.map(h => `<th>${h}</th>`).join('')}</tr></thead>`;
-      const body = data.map(row => `<tr>${headers.map(h => `<td>${row[h]}</td>`).join('')}</tr>`).join('');
+      const escapeHtml = s => String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+      const body = data.map(row => `<tr>${headers.map(h => `<td>${escapeHtml(row[h])}</td>`).join('')}</tr>`).join('');
       table.innerHTML += `<tbody>${body}</tbody>`;
       $(table).DataTable();
       table.style.display = '';

--- a/src/app.js
+++ b/src/app.js
@@ -57,11 +57,21 @@ function render(hash) {
 window.addEventListener('hashchange', () => render(location.hash));
 render(location.hash || '#about');
 
-// Dark mode toggle
+// Dark mode toggle with persistence
 const btn = document.getElementById('modeToggle');
+
+function applyTheme(dark) {
+  document.body.classList.toggle('dark-mode', dark);
+  btn.textContent = dark ? 'Light Mode' : 'Dark Mode';
+}
+
+// Apply saved preference on startup
+applyTheme(localStorage.getItem('theme') === 'dark');
+
 btn.addEventListener('click', () => {
-  document.body.classList.toggle('dark-mode');
-  btn.textContent = document.body.classList.contains('dark-mode') ? 'Light Mode' : 'Dark Mode';
+  const useDark = !document.body.classList.contains('dark-mode');
+  applyTheme(useDark);
+  localStorage.setItem('theme', useDark ? 'dark' : 'light');
 });
 
 // Register service worker


### PR DESCRIPTION
## Summary
- remember dark mode preference in localStorage
- escape HTML when building DataTables
- add instructions for adding new modules in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bff3b458c832c86354e3cb741a579