### PR TITLE
Add slide-in navigation and websocket improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,36 +6,32 @@
   <link rel="manifest" href="manifest.json">
   <title>Free Web Tools</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    body.dark-mode { background-color: #121212; color: #ffffff; }
-  </style>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="#">Free Web Tools</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item"><a class="nav-link" href="#images">Images to PDF</a></li>
-          <li class="nav-item"><a class="nav-link" href="#ocr">Image OCR</a></li>
-          <li class="nav-item"><a class="nav-link" href="#datatable">JSON to Table</a></li>
-          <li class="nav-item"><a class="nav-link" href="#tree">JSON Tree</a></li>
-          <li class="nav-item"><a class="nav-link" href="#pdftoword">PDF→Word</a></li>
-          <li class="nav-item"><a class="nav-link" href="#wordtopdf">Word→PDF</a></li>
-          <li class="nav-item"><a class="nav-link" href="#compresspdf">Compress PDF</a></li>
-          <li class="nav-item"><a class="nav-link" href="#editor">WYSIWYG</a></li>
-          <li class="nav-item"><a class="nav-link" href="#xmljson">XML↔JSON</a></li>
-          <li class="nav-item"><a class="nav-link" href="#apitester">API Tester</a></li>
-          <li class="nav-item"><a class="nav-link" href="#websocket">WebSocket</a></li>
-          <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
-        </ul>
-        <button id="modeToggle" class="btn btn-outline-secondary">Dark Mode</button>
-      </div>
-    </div>
+  <header class="top-bar">
+    <button id="menuToggle" class="menu-icon" aria-label="Menu">&#9776;</button>
+    <span class="brand">Free Web Tools</span>
+  </header>
+  <nav id="sideMenu" class="side-menu">
+    <button id="closeMenu" class="close-icon" aria-label="Close">&times;</button>
+    <ul>
+      <li><a href="#images">Images to PDF</a></li>
+      <li><a href="#ocr">Image OCR</a></li>
+      <li><a href="#datatable">JSON to Table</a></li>
+      <li><a href="#tree">JSON Tree</a></li>
+      <li><a href="#pdftoword">PDF to Word</a></li>
+      <li><a href="#wordtopdf">Word to PDF</a></li>
+      <li><a href="#compresspdf">Compress PDF</a></li>
+      <li><a href="#editor">WYSIWYG</a></li>
+      <li><a href="#xmljson">XML to JSON</a></li>
+      <li><a href="#apitester">API Tester</a></li>
+      <li><a href="#websocket">WebSocket</a></li>
+      <li><a href="#about">About</a></li>
+      <li><button id="modeToggle" class="btn btn-link p-0">Dark Mode</button></li>
+    </ul>
   </nav>
+  <div id="overlay" class="overlay"></div>
   <main class="container my-4" id="app"></main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
@@ -53,5 +49,6 @@
   <script src="https://cdn.jsdelivr.net/npm/x2js@3.6.1/x2js.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/tesseract.js@4.0.2/dist/tesseract.min.js"></script>
   <script type="module" src="src/app.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/modules/websocketTester.js
+++ b/modules/websocketTester.js
@@ -1,35 +1,94 @@
 export function initWebsocketTester(container) {
   container.innerHTML = `
     <h2>WebSocket Tester</h2>
-    <input id="wsUrl" class="form-control" placeholder="wss://ws.postman-echo.com/raw" />
+    <div class="input-group">
+      <input id="wsUrl" class="form-control" placeholder="wss://ws.postman-echo.com/raw" />
+      <span id="wsStatus" class="status-indicator"></span>
+    </div>
+    <div id="wsError" class="text-danger small mt-1"></div>
     <button id="connect" class="btn btn-primary mt-2">Connect</button>
     <div id="wsControls" style="display:none" class="mt-2">
       <input id="wsMessage" class="form-control" placeholder="Message" />
       <button id="sendMsg" class="btn btn-secondary mt-2">Send</button>
       <button id="close" class="btn btn-danger mt-2 ms-2">Close</button>
     </div>
-    <pre id="log" class="mt-3"></pre>
+    <div id="history" class="message-history mt-3"></div>
   `;
+
   let socket;
-  const log = msg => {
-    container.querySelector('#log').textContent += msg + '\n';
-  };
-  container.querySelector('#connect').addEventListener('click', () => {
-    const url = container.querySelector('#wsUrl').value;
+  let reconnectDelay = 1000;
+  let manualClose = false;
+
+  const statusEl = container.querySelector('#wsStatus');
+  const historyEl = container.querySelector('#history');
+  const connectBtn = container.querySelector('#connect');
+
+  function setStatus(state) {
+    statusEl.className = 'status-indicator ' + state;
+  }
+
+  function addMessage(type, msg) {
+    const div = document.createElement('div');
+    const prefix = type === 'send' ? '>>' : type === 'recv' ? '<<' : '!!';
+    div.textContent = `[${new Date().toLocaleTimeString()}] ${prefix} ${msg}`;
+    historyEl.appendChild(div);
+    historyEl.scrollTop = historyEl.scrollHeight;
+  }
+
+  function showError(msg) {
+    container.querySelector('#wsError').textContent = msg;
+  }
+
+  function connect() {
+    const url = container.querySelector('#wsUrl').value.trim();
+    if (!/^wss?:\/\//.test(url)) {
+      showError('Invalid WebSocket URL');
+      return;
+    }
+    showError('');
+    manualClose = false;
+    connectBtn.classList.add('loading');
+    setStatus('connecting');
     socket = new WebSocket(url);
-    log('Connecting to ' + url);
+    addMessage('info', 'Connecting to ' + url);
     socket.addEventListener('open', () => {
-      log('Connected');
+      setStatus('connected');
+      connectBtn.classList.remove('loading');
       container.querySelector('#wsControls').style.display = '';
+      reconnectDelay = 1000;
+      addMessage('info', 'Connected');
     });
-    socket.addEventListener('message', e => log('<< ' + e.data));
-    socket.addEventListener('close', () => log('Closed'));
-    socket.addEventListener('error', e => log('Error: ' + e));
-  });
+    socket.addEventListener('message', e => addMessage('recv', e.data));
+    socket.addEventListener('close', () => {
+      setStatus('');
+      connectBtn.classList.remove('loading');
+      container.querySelector('#wsControls').style.display = 'none';
+      addMessage('info', 'Closed');
+      if (!manualClose) {
+        setTimeout(connect, reconnectDelay);
+        reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+      }
+    });
+    socket.addEventListener('error', e => {
+      console.error(e);
+      addMessage('error', e.message || 'Error');
+    });
+  }
+
+  connectBtn.addEventListener('click', connect);
+
   container.querySelector('#sendMsg').addEventListener('click', () => {
     const msg = container.querySelector('#wsMessage').value;
-    socket.send(msg);
-    log('>> ' + msg);
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(msg);
+      addMessage('send', msg);
+    }
   });
-  container.querySelector('#close').addEventListener('click', () => socket.close());
+
+  container.querySelector('#close').addEventListener('click', () => {
+    manualClose = true;
+    socket?.close();
+  });
+
+  setStatus('');
 }

--- a/script.js
+++ b/script.js
@@ -1,0 +1,21 @@
+// Handle side menu toggle
+const menuToggle = document.getElementById('menuToggle');
+const sideMenu = document.getElementById('sideMenu');
+const closeMenu = document.getElementById('closeMenu');
+const overlay = document.getElementById('overlay');
+
+function openMenu() {
+  sideMenu.classList.add('active');
+  overlay.classList.add('active');
+}
+function closeMenuFn() {
+  sideMenu.classList.remove('active');
+  overlay.classList.remove('active');
+}
+menuToggle?.addEventListener('click', openMenu);
+closeMenu?.addEventListener('click', closeMenuFn);
+overlay?.addEventListener('click', closeMenuFn);
+// Close menu when clicking a link
+sideMenu?.querySelectorAll('a,button').forEach(el => {
+  el.addEventListener('click', closeMenuFn);
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,13 @@
 // Increment the version to bust the cache when deploying a new release
-const CACHE_VERSION = 'v4';
+const CACHE_VERSION = 'v5';
 const CACHE_NAME = `free-web-tools-${CACHE_VERSION}`;
 const ASSETS = [
   './',
   './index.html',
   './manifest.json',
   './src/app.js',
+  './styles.css',
+  './script.js',
   './modules/imagesToPdf.js',
   './modules/jsonToDataTable.js',
   './modules/jsonTreeView.js',

--- a/src/app.js
+++ b/src/app.js
@@ -62,6 +62,7 @@ const btn = document.getElementById('modeToggle');
 
 function applyTheme(dark) {
   document.body.classList.toggle('dark-mode', dark);
+  document.body.classList.toggle('light-mode', !dark);
   btn.textContent = dark ? 'Light Mode' : 'Dark Mode';
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,134 @@
+:root {
+  --bg-color: #333;
+  --text-color: #fff;
+  --accent-color: #1E90FF;
+}
+
+body {
+  background: var(--bg-color);
+  color: var(--text-color);
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+body.dark-mode {
+  --bg-color: #333;
+  --text-color: #fff;
+}
+
+/* Light theme overrides applied when body has .light-mode */
+body.light-mode {
+  --bg-color: #f7f7f7;
+  --text-color: #333;
+}
+
+header.top-bar {
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+header .brand {
+  margin-left: 10px;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.menu-icon, .close-icon {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.side-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 250px;
+  height: 100%;
+  background: var(--bg-color);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+  padding-top: 60px;
+}
+.side-menu.active { transform: translateX(0); }
+.side-menu ul { list-style: none; padding: 0; margin: 0; }
+.side-menu li a, .side-menu li button {
+  display: block;
+  padding: 10px 20px;
+  color: var(--text-color);
+  text-decoration: none;
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+}
+.side-menu li a:hover, .side-menu li button:hover {
+  background: rgba(255,255,255,0.1);
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  z-index: 999;
+}
+.overlay.active { display: block; }
+
+/* Message history */
+.message-history {
+  background: rgba(0,0,0,0.1);
+  padding: 10px;
+  height: 200px;
+  overflow-y: auto;
+  font-family: monospace;
+}
+
+.status-indicator {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: red;
+  margin-left: 8px;
+}
+.status-indicator.connected { background: green; }
+.status-indicator.connecting { background: var(--accent-color); }
+
+/* Connect button loading */
+#connect.loading {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.7;
+}
+#connect.loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px;
+  border: 2px solid var(--text-color);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+
+button, .btn {
+  transition: transform 0.2s;
+}
+button:hover, .btn:hover {
+  transform: scale(1.05);
+}
+


### PR DESCRIPTION
## Summary
- implement hamburger slide-in navigation
- add custom site styling and script helpers
- enhance WebSocket tester with status indicator, history panel and reconnect logic
- support light and dark themes with persistent toggle
- bump service worker cache version

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685c0130516c832caf02d31f7916fc87